### PR TITLE
Update JWebbinar notebook kernels

### DIFF
--- a/jnb/run_q3dfit.ipynb
+++ b/jnb/run_q3dfit.ipynb
@@ -769,9 +769,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "JWebbinar",
    "language": "python",
-   "name": "python3"
+   "name": "jwebbinar"
   },
   "language_info": {
    "codemirror_mode": {
@@ -783,7 +783,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/jnb/run_q3dfit_MIRlines_Spitzer.ipynb
+++ b/jnb/run_q3dfit_MIRlines_Spitzer.ipynb
@@ -377,12 +377,12 @@
     "If convolution is desired, then `spectres_convolve` and `spect_instrum` are required variables.\n",
     "\n",
     "Specify the desired convolution method using `spect_instrum`. The syntax is: \n",
-    "`spect_instrum = {INSTRUMENT:[METHOD]}`, which should mirror the filename in `q3dfit/data/dispersion_files/`. METHOD specifies the grating, spectral resolution [R], Δλ FWHM in [Å], velocity in [km/s].\n",
+    "`spect_instrum = {INSTRUMENT:[METHOD]}`, which should mirror the filename in `q3dfit/data/dispersion_files/`. METHOD specifies the grating, spectral resolution [R], \u0394\u03bb FWHM in [\u00c5], velocity in [km/s].\n",
     "\n",
     "Examples convolving with: \n",
     "1. flat R=500: `spect_instrum = {'flat':['R500']}`\n",
     "2. flat velocity FWHM = 30km/s: `spect_instrum = {'flat':['kms30']}`\n",
-    "3. flat Δλ FWHM = 4 Å: `spect_instrum = {'flat':['dlambda4']}`\n",
+    "3. flat \u0394\u03bb FWHM = 4 \u00c5: `spect_instrum = {'flat':['dlambda4']}`\n",
     "4. JWST NIRSPEC / G140M: `spect_instrum = {'JWST_NIRSPEC':['G140M']}`\n",
     "\n",
     "If desired flat convolution file does not exist, then a new file will be created automatically. "
@@ -410,7 +410,7 @@
     "1. First, run `from q3dfit.common.spectConvol import dispFile` and initialize: `dispObj = dispFile()`\n",
     "2. Create the files with either method A or B\n",
     "\n",
-    "2.(A) Create a flat R=120 dispersion file from 10 μm to 30 μm: \n",
+    "2.(A) Create a flat R=120 dispersion file from 10 \u03bcm to 30 \u03bcm: \n",
     "\n",
     "`dispObj.make_dispersion(120,WAVELEN=[10,30],TYPE='R')`\n",
     "\n",
@@ -516,7 +516,7 @@
     "    - `center_rest`: a float list of wavelengths of each subplot center, in the rest frame, which are converted to obs. frame\n",
     "\n",
     "Optional keywords:\n",
-    "* `size`: float list of widths in wavelength space of each subplot; if not specified, default is 300 $Å$\n",
+    "* `size`: float list of widths in wavelength space of each subplot; if not specified, default is 300 $\u00c5$\n",
     "* `IR`: set to `True` to use infrared-style plot"
    ]
   },
@@ -646,9 +646,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "JWebbinar",
    "language": "python",
-   "name": "python3"
+   "name": "jwebbinar"
   },
   "language_info": {
    "codemirror_mode": {

--- a/jnb/run_q3dfit_MIRlines_mockETCcube.ipynb
+++ b/jnb/run_q3dfit_MIRlines_mockETCcube.ipynb
@@ -418,12 +418,12 @@
     "If convolution is desired, then `spectres_convolve` and `spect_instrum` are required variables.\n",
     "\n",
     "Specify the desired convolution method using `spect_instrum`. The syntax is: \n",
-    "`spect_instrum = {INSTRUMENT:[METHOD]}`, which should mirror the filename in `q3dfit/data/dispersion_files/`. METHOD specifies the grating, spectral resolution [R], Δλ FWHM in [Å], velocity in [km/s].\n",
+    "`spect_instrum = {INSTRUMENT:[METHOD]}`, which should mirror the filename in `q3dfit/data/dispersion_files/`. METHOD specifies the grating, spectral resolution [R], \u0394\u03bb FWHM in [\u00c5], velocity in [km/s].\n",
     "\n",
     "Examples convolving with: \n",
     "1. flat R=500: `spect_instrum = {'flat':['R500']}`\n",
     "2. flat velocity FWHM = 30km/s: `spect_instrum = {'flat':['kms30']}`\n",
-    "3. flat Δλ FWHM = 4 Å: `spect_instrum = {'flat':['dlambda4']}`\n",
+    "3. flat \u0394\u03bb FWHM = 4 \u00c5: `spect_instrum = {'flat':['dlambda4']}`\n",
     "4. JWST NIRSPEC / G140M: `spect_instrum = {'JWST_NIRSPEC':['G140M']}`\n",
     "\n",
     "If desired flat convolution file does not exist, then a new file will be created automatically. "
@@ -450,7 +450,7 @@
     "1. First, run `from q3dfit.common.spectConvol import dispFile` and initialize: `dispObj = dispFile()`\n",
     "2. Create the files with either method A or B\n",
     "\n",
-    "2.(A) Create a flat R=120 dispersion file from 10 μm to 30 μm: \n",
+    "2.(A) Create a flat R=120 dispersion file from 10 \u03bcm to 30 \u03bcm: \n",
     "\n",
     "`dispObj.make_dispersion(120,WAVELEN=[10,30],TYPE='R')`\n",
     "\n",
@@ -555,7 +555,7 @@
     "    - `center_rest`: a float list of wavelengths of each subplot center, in the rest frame, which are converted to obs. frame\n",
     "\n",
     "Optional keywords:\n",
-    "* `size`: float list of widths in wavelength space of each subplot; if not specified, default is 300 $Å$\n",
+    "* `size`: float list of widths in wavelength space of each subplot; if not specified, default is 300 $\u00c5$\n",
     "* `IR`: set to `True` to use infrared-style plot"
    ]
   },
@@ -724,9 +724,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "JWebbinar",
    "language": "python",
-   "name": "python3"
+   "name": "jwebbinar"
   },
   "language_info": {
    "codemirror_mode": {

--- a/jnb/run_q3dfit_nirspec-etc.ipynb
+++ b/jnb/run_q3dfit_nirspec-etc.ipynb
@@ -660,9 +660,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "JWebbinar",
    "language": "python",
-   "name": "python3"
+   "name": "jwebbinar"
   },
   "language_info": {
    "codemirror_mode": {
@@ -674,7 +674,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated 4 notebooks to use the JWebbinar kernel.

Also included are character changes.  These won't affect anything behavior or display wise, but it will make it so subsequent logins to the platform don't generate backup files, due to `git diff` showing a differences like:

```
diff --git a/jnb/run_q3dfit_MIRlines_Spitzer.ipynb b/jnb/run_q3dfit_MIRlines_Spitzer.ipynb
index 6014830..c709dbc 100644
--- a/jnb/run_q3dfit_MIRlines_Spitzer.ipynb
+++ b/jnb/run_q3dfit_MIRlines_Spitzer.ipynb
@@ -377,12 +377,12 @@
     "If convolution is desired, then `spectres_convolve` and `spect_instrum` are required variables.\n",
     "\n",
     "Specify the desired convolution method using `spect_instrum`. The syntax is: \n",
-    "`spect_instrum = {INSTRUMENT:[METHOD]}`, which should mirror the filename in `q3dfit/data/dispersion_files/`. METHOD specifies the grating, spectral resolution [R], Δλ FWHM in [Å], velocity in [km/s].\n",
+    "`spect_instrum = {INSTRUMENT:[METHOD]}`, which should mirror the filename in `q3dfit/data/dispersion_files/`. METHOD specifies the grating, spectral resolution [R], \u0394\u03bb FWHM in [\u00c5], velocity in [km/s].\n",
     "\n",
```