### PR TITLE
Hot fix nocrash (issue #30)

### DIFF
--- a/q3dfit/q3df.py
+++ b/q3dfit/q3df.py
@@ -69,4 +69,4 @@ def q3dfit(initproc, cols=None, rows=None, onefit=False, ncores=1,
             mpistr = mpipath + mpistr
         import sys
         call([mpistr, "-n", str(ncores), "python", filename,
-              initproc, cols, rows, str(onefit), str(quiet)])
+              initproc, cols, rows, str(onefit), str(quiet), str(nocrash)])

--- a/q3dfit/q3df_helperFunctions.py
+++ b/q3dfit/q3df_helperFunctions.py
@@ -120,7 +120,7 @@ def q3df_oneCore(inobj, cols=None, rows=None, onefit=False,
 
 
 def q3df_multiCore(rank, size, inobj, cols=None, rows=None,
-                   onefit=False, ncores=1, quiet=True):
+                   onefit=False, ncores=1, quiet=True, nocrash=False):
 
     '''
     q3df setup for multi-threaded execution
@@ -172,7 +172,7 @@ def q3df_multiCore(rank, size, inobj, cols=None, rows=None,
     # execute FITLOOP
     execute_fitloop(nspax_thisCore, colarr, rowarr, cube, q3di,
                     linelist, specConv, onefit, quiet, logfile=logfile,
-                    core=rank+1)
+                    core=rank+1, nocrash=nocrash)
     if logfile is None:
         from sys import stdout
         logtmp = stdout
@@ -223,4 +223,10 @@ if __name__ == "__main__":
         quiet = True
     else:
         quiet = False
-    q3df_multiCore(rank, size, inobj, cols, rows, onefit, quiet)
+    # nocrash option
+    if argv[6].startswith("T"):
+        nocrash = True
+    else:
+        nocrash = False
+
+    q3df_multiCore(rank, size, inobj, cols, rows, onefit, quiet, nocrash=nocrash)


### PR DESCRIPTION
Fixed issue (#30) where q3dfit crashes in a given core after finding an error. The error could occur when running the fit process over the full FoV. The result was blank columns (pixels not fitted) in the maps produced from the fitted parameters.

The solution was adding the "nocrash" option in the internal functions that were calling during the multi-core fitting process.     